### PR TITLE
(MAINT) Update to maintained jwt repo

### DIFF
--- a/gripcontrol.go
+++ b/gripcontrol.go
@@ -11,7 +11,7 @@ import "fmt"
 import "unicode/utf8"
 import "encoding/json"
 import "strings"
-import "github.com/dgrijalva/jwt-go"
+import "github.com/golang-jwt/jwt"
 import "net/url"
 import "encoding/base64"
 

--- a/gripcontrol_test.go
+++ b/gripcontrol_test.go
@@ -11,7 +11,7 @@ import ("testing"
         "time"
         "encoding/json"
         "encoding/base64"
-        "github.com/dgrijalva/jwt-go"
+        "github.com/golang-jwt/jwt"
         "github.com/stretchr/testify/assert")
 
 func TestCreateHold(t *testing.T) {


### PR DESCRIPTION
**What**
Update the `github.com/dgrijalva/jwt-go` dependency to be `github.com/golang-jwt/jwt`

**Why**
[`github.com/dgrijalva/jwt-go`](https://github.com/dgrijalva/jwt-go) has been archived and moved to a maintained repo here https://github.com/golang-jwt/jwt . 
See https://github.com/dgrijalva/jwt-go#this-repository-is-no-longer-maintaned for more info. 

This indirect dependency was raised as a security issue as part of an ongoing exercise to open source a private repository.